### PR TITLE
Fix hash assignation from selector

### DIFF
--- a/lib/puppet-lint/plugins/check_unquoted_string_in_case.rb
+++ b/lib/puppet-lint/plugins/check_unquoted_string_in_case.rb
@@ -5,14 +5,21 @@ def type_indexes(type)
   tokens.each_index do |token_idx|
     if tokens[token_idx].type == type
       depth = 0
+      start = token_idx
       tokens[(token_idx + 1)..-1].each_index do |case_token_idx|
         idx = case_token_idx + token_idx + 1
         if tokens[idx].type == :LBRACE
           depth += 1
+          if depth == 2
+            type_indexes << {:start => start, :end => idx}
+          end
         elsif tokens[idx].type == :RBRACE
+          if depth == 2
+            start = idx
+          end
           depth -= 1
           if depth == 0
-            type_indexes << {:start => token_idx, :end => idx}
+            type_indexes << {:start => start, :end => idx}
             break
           end
         end

--- a/spec/puppet-lint/plugins/check_unquoted_string_in_case/check_unquoted_string_in_selector_spec.rb
+++ b/spec/puppet-lint/plugins/check_unquoted_string_in_case/check_unquoted_string_in_selector_spec.rb
@@ -145,5 +145,28 @@ describe 'unquoted_string_in_selector' do
         )
       end
     end
+
+    context 'hashes in case' do
+      let(:code) do
+        <<-EOS
+        $postfix_configuration = $configuration ? {
+          'relay'     => {
+            relayhost => '[example.com]:587',
+            satellite => true,
+          },
+          'smarthost' => {
+            smtp_listen       => 'all',
+            master_submission => 'submission inet n - - - - smtpd -o smtpd_tls_security_level=encrypt',
+            mta               => true,
+            relayhost         => 'direct',
+          },
+        }
+        EOS
+      end
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+    end
   end
 end


### PR DESCRIPTION
When a selector is used to assign a hash to a variable, the checker currently reports missing quotes around the hash keys:

```puppet
$postfix_configuration = $configuration ? {
  'relay'     => {
    relayhost => '[example.com]:587',
    satellite => true,
  },
  'smarthost' => {
    smtp_listen       => 'all',
    master_submission => 'submission inet n - - - - smtpd -o smtpd_tls_security_level=encrypt',
    mta               => true,
    relayhost         => 'direct',
  },
}
```

```
foo.pp - WARNING: unquoted string in selector on line 3
foo.pp - WARNING: unquoted string in selector on line 4
foo.pp - WARNING: unquoted string in selector on line 7
foo.pp - WARNING: unquoted string in selector on line 8
foo.pp - WARNING: unquoted string in selector on line 9
foo.pp - WARNING: unquoted string in selector on line 10
```

This Pull-Request fix this problem.