### PR TITLE
Support namespaced data types in selectors

### DIFF
--- a/lib/puppet-lint/plugins/check_unquoted_string_in_case.rb
+++ b/lib/puppet-lint/plugins/check_unquoted_string_in_case.rb
@@ -36,7 +36,7 @@ def notify_tokens(type, sep_type, message)
       if r.type == sep_type
         s = r.prev_token
         while (s.type != :NEWLINE) && (s.type != :LBRACE)
-          if (s.type == :NAME || s.type == :CLASSREF) && (s.type != :TYPE)
+          if s.type == :NAME || (s.type == :CLASSREF && !s.value.include?('::'))
             notify :warning, {
               :message => message,
               :line    => s.line,

--- a/spec/puppet-lint/plugins/check_unquoted_string_in_case/check_unquoted_string_in_selector_spec.rb
+++ b/spec/puppet-lint/plugins/check_unquoted_string_in_case/check_unquoted_string_in_selector_spec.rb
@@ -51,6 +51,22 @@ describe 'unquoted_string_in_selector' do
         expect(problems).to contain_warning(msg).on_line(2).in_column(11)
       end
     end
+
+    context ':TYPE in case' do
+      let(:code) do
+        <<-PUPPET
+          $listen_socket = $service_bind ? {
+            Undef                   => undef,
+            Stdlib::IP::Address::V6 => "[${service_bind}]:${service_port}",
+            default                 => "${service_bind}:${service_port}",
+          }
+        PUPPET
+      end
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+    end
   end
 
   context 'with fix enabled' do


### PR DESCRIPTION
puppet-lint detects namespaced data types as CLASSREF instead of TYPE because lexically they are identical (https://github.com/rodjek/puppet-lint/issues/485). Since the built in data types are hardcoded and detected as TYPE, we can assume that if the CLASSREF includes `::` it is probably a namespaced data type and thus valid syntax. This means unnamespaced custom data types are unsupported, but that's reserved for Puppet built-ins anyway.

This also drops the s.type != :TYPE check because it's redundant.  s.type can't be both (:NAME or :CLASSREF) and :TYPE.